### PR TITLE
update compliance throughout wizard UI to be conformance

### DIFF
--- a/views/clause_form.pug
+++ b/views/clause_form.pug
@@ -37,13 +37,13 @@ block form
           | #{item.frDescription}
     .form-group
       label(for='compliance')
-        span.field-name Determination of compliance (English) 
+        span.field-name Determination of conformance (English) 
       textarea#compliance.form-control(name='compliance' rows='10')
         if itemExists
           | #{item.compliance}
     .form-group
       label(for='frCompliance')
-        span.field-name Determination of compliance (French) 
+        span.field-name Determination of conformance (French) 
       textarea#frCompliance.form-control(lang='fr' name='frCompliance' rows='10')
         if itemExists
           | #{item.frCompliance}

--- a/views/download_test_table_en.pug
+++ b/views/download_test_table_en.pug
@@ -16,7 +16,7 @@ html(lang='en')
         thead
           tr.active
             th(scope='col') EN 301 549 (2018) clauses
-            th(scope='col') Determination of compliance
+            th(scope='col') Determination of conformance
         tbody
           each item in test_list
             tr

--- a/views/includes/table.pug
+++ b/views/includes/table.pug
@@ -3,7 +3,7 @@ if item_list.length > 0
     thead
       tr.active
         th.col-sm-6(scope='col') EN 301 549 clause
-        th.col-sm-4(scope='col') Determination of compliance
+        th.col-sm-4(scope='col') Determination of conformance
         th(scope='col') Supports?
         th.col-sm-4(scope='col') Explanation
     tbody

--- a/views/includes/table_not_fillable.pug
+++ b/views/includes/table_not_fillable.pug
@@ -3,7 +3,7 @@ if item_list.length > 0
     thead
       tr.active
         th.col-sm-6(scope='col') EN 301 549 clause
-        th.col-sm-4(scope='col') Determination of compliance
+        th.col-sm-4(scope='col') Determination of conformance
     tbody
       each item in item_list
         tr


### PR DESCRIPTION
We need to update the word "compliance throughout the Ui of the wizard, The French was already correct.