### PR TITLE
Fix JavaScript console errors in wizard step handlers

### DIFF
--- a/public/a11y-req.js
+++ b/public/a11y-req.js
@@ -409,6 +409,12 @@ $(document).on("wb-updated.wb-tabs", ".wb-tabs", function (event, $newPanel) {
 var uncheckedStep1ClauseIds = [];
 var checkedStep1QuestionsIds = [];
 var previouscheckedStep1QuestionsIds = [];
+var uncheckedStep2ClauseIds = [];
+var checkedStep2QuestionsIds = [];
+var previouscheckedStep2QuestionsIds = [];
+var uncheckedStep3ClauseIds = [];
+var checkedStep3QuestionsIds = [];
+var previouscheckedStep3QuestionsIds = [];
 var undo = false;
 
 var undoHandler = function () {


### PR DESCRIPTION
- Add missing variable declarations for steps 2 and 3 question tracking
- Declare uncheckedStep2ClauseIds, checkedStep2QuestionsIds, previouscheckedStep2QuestionsIds
- Declare uncheckedStep3ClauseIds, checkedStep3QuestionsIds, previouscheckedStep3QuestionsIds
- Resolves 'ReferenceError: checkedStep2QuestionsIds is not defined' console errors
- Resolves 'ReferenceError: checkedStep3QuestionsIds is not defined' console errors
- Ensures consistent variable naming pattern across all wizard steps
- Improves JavaScript error handling and step transition reliability