### PR TITLE
Update style.css with visual fix for toggle button switches

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -302,7 +302,7 @@ button.toggle-switch {
   display: inline-block;
   border: 1px solid #777;
   border-radius: 20px;
-  padding: 4px 10px;
+  padding: 4px 50px 4px 10px;
   background: #f5f5f5;
   position: relative;
   min-width: 220px;
@@ -321,6 +321,7 @@ button.toggle-switch::before {
   width: 18px;
   height: 18px;
   border-radius: 50%;
+  border: 1px solid #777;
   background: #fff;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   transition: right 0.15s ease;
@@ -330,6 +331,6 @@ button.toggle-switch[aria-checked="true"]::before {
   background: #fff;
 }
 button.toggle-switch[aria-checked="false"]::before {
-  right: 6px;
+  right: 25px;
 }
 


### PR DESCRIPTION
Widens toggle button so white circle no longer covers text. White circle now moves to visually reflect the on/off checked state, thereby fixing use of colour WCAG failure.